### PR TITLE
Remove ggpubr from suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,6 @@ Imports:
   ingredients
 Suggests: 
     gower,
-    ggpubr,
     ranger,
     testthat
 URL: https://ModelOriented.github.io/DALEX/, https://github.com/ModelOriented/DALEX


### PR DESCRIPTION
We don't use this package so there is no need to suggest it