### PR TITLE
Replace all `neighbours` with `neighbors`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: DALEX
 Title: moDel Agnostic Language for Exploration and eXplanation
-Version: 2.1.0
+Version: 2.1.1
 Authors@R: c(person("Przemyslaw", "Biecek", email = "przemyslaw.biecek@gmail.com", role = c("aut", "cre"), 
              comment = c(ORCID = "0000-0001-8423-1823")),
     person("Szymon", "Maksymiuk", role = "aut",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+DALEX 2.1.1
+---------------------------------------------------------------
+* All encouters of `nieghbour(s)` (EN-spelling) were replaced with `neighbor(s)` (US-spelling) for the consistency and backword compatibility.
+* Fixed bug when `predict_diagnostics` raised error if  `neighbor` value was higer than `nrow(explainer$data)`.
+
 DALEX 2.1.0
 ---------------------------------------------------------------
 * Added new parameter (`predict_function_target_column`) to `explain` function that allows specifying positive class in binary classification tasks ([#250](https://github.com/ModelOriented/DALEX/issues/250)).

--- a/R/plot_predict_diagnostics.R
+++ b/R/plot_predict_diagnostics.R
@@ -34,7 +34,7 @@
 plot.predict_diagnostics <- function(x, ...) {
   # if variables are not specified then gow with histogram
   if (is.null(x$variables)) {
-    df <- rbind(x$histogram_neighbours, x$histogram_all)
+    df <- rbind(x$histogram_neighbors, x$histogram_all)
     p.value <- x$test$p.value
     statistic <- x$test$statistic
     cut_points <- x$cut_points

--- a/R/predict_diagnostics.R
+++ b/R/predict_diagnostics.R
@@ -53,32 +53,32 @@
 predict_diagnostics <-  function(explainer, new_observation, variables = NULL, ..., nbins = 20, neighbors = 50, distance = gower::gower_dist) {
   test_explainer(explainer, has_data = TRUE, function_name = "predict_diagnostics")
 
-  neighbours_id <- select_neighbours_id(new_observation, explainer$data, n = neighbors, distance = distance)
+  neighbors_id <- select_neighbors_id(new_observation, explainer$data, n = neighbors, distance = distance)
 
 
   # if variables = NULL then histograms with distribution of residuals are compared against each other
   if (is.null(variables)) {
     residuals_all <- explainer$residual_function(explainer$model, explainer$data, explainer$y, explainer$predict_function)
-    residuals_sel <- residuals_all[neighbours_id]
-    residuals_other <- residuals_all[-neighbours_id]
+    residuals_sel <- residuals_all[neighbors_id]
+    residuals_other <- residuals_all[-neighbors_id]
 
     cut_points <- signif(pretty(residuals_other, nbins), 3)
     test.res <- ks.test(residuals_other, residuals_sel)
 
-    df1 <- data.frame(as.data.frame(table(cut(residuals_sel, cut_points))/length(residuals_sel)), direction = "neighbours")
+    df1 <- data.frame(as.data.frame(table(cut(residuals_sel, cut_points))/length(residuals_sel)), direction = "neighbors")
     df2 <- data.frame(as.data.frame(-table(cut(residuals_other, cut_points))/length(residuals_other)), direction = "all")
 
     res <- list(variables = variables,
-                histogram_neighbours = df1,
+                histogram_neighbors = df1,
                 histogram_all = df2,
                 test = test.res,
                 cut_points = cut_points,
-                neighbours_id = neighbours_id)
+                neighbors_id = neighbors_id)
   } else {
     # if variables is not null then we need to plot either categorical or continouse fidelity plot
     cp_neighbors <- ingredients::ceteris_paribus(explainer,
-                                                 new_observation = explainer$data[neighbours_id, ],
-                                                 y = explainer$y[neighbours_id],
+                                                 new_observation = explainer$data[neighbors_id, ],
+                                                 y = explainer$y[neighbors_id],
                                                  variables = variables,
                                                  ...)
     cp_new_instance <- ingredients::ceteris_paribus(explainer,
@@ -88,7 +88,7 @@ predict_diagnostics <-  function(explainer, new_observation, variables = NULL, .
     res <- list(variables = variables,
                 cp_neighbors = cp_neighbors,
                 cp_new_instance = cp_new_instance,
-                neighbours_id = neighbours_id)
+                neighbors_id = neighbors_id)
   }
   class(res) <- "predict_diagnostics"
   res
@@ -99,7 +99,7 @@ predict_diagnostics <-  function(explainer, new_observation, variables = NULL, .
 individual_diagnostics <- predict_diagnostics
 
 
-select_neighbours_id <- function(observation, data, variables = NULL, distance = gower::gower_dist, n = 50, frac = NULL) {
+select_neighbors_id <- function(observation, data, variables = NULL, distance = gower::gower_dist, n = 50, frac = NULL) {
   if (is.null(variables)) {
     variables <- intersect(colnames(observation),
                            colnames(data))

--- a/R/predict_diagnostics.R
+++ b/R/predict_diagnostics.R
@@ -53,6 +53,12 @@
 predict_diagnostics <-  function(explainer, new_observation, variables = NULL, ..., nbins = 20, neighbors = 50, distance = gower::gower_dist) {
   test_explainer(explainer, has_data = TRUE, function_name = "predict_diagnostics")
 
+
+  if (nrow(explainer$data) <= neighbors) {
+    warning("Value of neighbors has to be lower than number of rows in explainer$data. Setting neighbors to nrow(explainer$data)")
+    neighbors <- nrow(explainer$data) - 1
+  }
+
   neighbors_id <- select_neighbors_id(new_observation, explainer$data, n = neighbors, distance = distance)
 
 

--- a/tests/testthat/test_predict_diagnostics.R
+++ b/tests/testthat/test_predict_diagnostics.R
@@ -4,8 +4,16 @@ context("Check predict_diagnostics() function")
 ranger_rd  <- predict_diagnostics(explainer_classif_ranger, new_observation = titanic_imputed[1,-8])
 lm_rd <- predict_diagnostics(explainer_regr_lm, variables = c("surface", "floor"), new_observation = apartments[1,-1])
 
+
 test_that("Data wasn't provided", {
   expect_error(predict_diagnostics(explainer_wo_data, new_observation = titanic_imputed[1,-8]))
+})
+
+
+explainer_regr_lm_data_cut <- explain(model_regr_lm, data = apartments_test[1:40, ], y = apartments_test$m2.price[1:40], verbose = FALSE)
+
+test_that("Neighbors > explainer$data", {
+  expect_warning(predict_diagnostics(explainer_regr_lm_data_cut, new_observation = apartments_test[41,]), "has to be lower than number of rows")
 })
 
 test_that("Output format - plot",{

--- a/vignettes/vignette_titanic.Rmd
+++ b/vignettes/vignette_titanic.Rmd
@@ -174,7 +174,7 @@ explain_titanic_svm <- explain(model_titanic_svm, data = titanic_imputed,
                        colorize = FALSE)
 ```
  
-## k-Nearest Neighbours (kNN)
+## k-Nearest Neighbors (kNN)
 
 ```{r}
 library("caret")
@@ -183,7 +183,7 @@ model_titanic_knn <- knn3(survived ~ class + gender + age + sibsp +
 explain_titanic_knn <- explain(model_titanic_knn, data = titanic_imputed, 
                        y = titanic_imputed$survived, 
                        predict_function = function(m,x) predict(m, x)[,2],
-                       label = "k-Nearest Neighbours",
+                       label = "k-Nearest Neighbors",
                        colorize = FALSE)
 ```
 


### PR DESCRIPTION
Candidate fix for #364. All `neighbours` entries in the source were removed and replaced with `neighbor`. Solution tested with grep.