### PR TITLE
Fix baseline positions on subplots for local explanations (BreakDown, Shap) 

### DIFF
--- a/python/dalex/dalex/predict_explanations/_break_down/object.py
+++ b/python/dalex/dalex/predict_explanations/_break_down/object.py
@@ -210,17 +210,19 @@ class BreakDown(Explanation):
                 m = max_vars + 3
 
             if baseline is None:
-                baseline = _result.iloc[0, _result.columns.get_loc("cumulative")]
+                prediction_baseline = _result.iloc[0, _result.columns.get_loc("cumulative")]
+            else: 
+                prediction_baseline = baseline
 
-            df = plot.prepare_data_for_break_down_plot(_result, baseline, max_vars, rounding_function, digits)
+            df = plot.prepare_data_for_break_down_plot(_result, prediction_baseline, max_vars, rounding_function, digits)
 
             measure = ["relative"] * m
             measure[m - 1] = "total"
 
             fig.add_shape(
                 type='line',
-                x0=baseline,
-                x1=baseline,
+                x0=prediction_baseline,
+                x1=prediction_baseline,
                 y0=-1,
                 y1=m,
                 yref="paper",
@@ -240,7 +242,7 @@ class BreakDown(Explanation):
                 decreasing={"marker": {"color": vcolors[-1]}},
                 increasing={"marker": {"color": vcolors[1]}},
                 totals={"marker": {"color": vcolors[0]}},
-                base=baseline,
+                base=prediction_baseline,
                 hovertext=df['tooltip_text'].tolist(),
                 hoverinfo='text+delta',
                 hoverlabel={'bgcolor': 'rgba(0,0,0,0.8)'},

--- a/python/dalex/dalex/predict_explanations/_shap/object.py
+++ b/python/dalex/dalex/predict_explanations/_shap/object.py
@@ -216,15 +216,18 @@ class Shap(Explanation):
                 m = max_vars + 1
 
             if baseline is None:
-                baseline = _intercept_list[i]
+                prediction_baseline = _intercept_list[i]
+            else: 
+                prediction_baseline = baseline
+
             prediction = _prediction_list[i]
 
-            df = plot.prepare_data_for_shap_plot(_result, baseline, prediction, max_vars, rounding_function, digits)
+            df = plot.prepare_data_for_shap_plot(_result, prediction_baseline, prediction, max_vars, rounding_function, digits)
 
             fig.add_shape(
                 type='line',
-                x0=baseline,
-                x1=baseline,
+                x0=prediction_baseline,
+                x1=prediction_baseline,
                 y0=-1,
                 y1=m,
                 yref="paper",
@@ -240,7 +243,7 @@ class Shap(Explanation):
                 textposition="outside",
                 text=df['label_text'].tolist(),
                 marker_color=[vcolors[int(c)] for c in df['sign'].tolist()],
-                base=baseline,
+                base=prediction_baseline,
                 hovertext=df['tooltip_text'].tolist(),
                 hoverinfo='text',
                 hoverlabel={'bgcolor': 'rgba(0,0,0,0.8)'},
@@ -259,7 +262,7 @@ class Shap(Explanation):
             plot_height += m * bar_width + (m + 1) * bar_width / 4
 
             if min_max is None:
-                cum = df.contribution.values + baseline
+                cum = df.contribution.values + prediction_baseline
                 min_max_margin = cum.ptp() * 0.15
                 temp_min_max[0] = np.min([temp_min_max[0], cum.min() - min_max_margin])
                 temp_min_max[1] = np.max([temp_min_max[1], cum.max() + min_max_margin])


### PR DESCRIPTION
Currently, the default starting x point for the bars on the plots for BreakDown and Shap is the average prediction (it is applied for `baseline = None` parameter) . 

However, the `baseline` is set only for the first explained prediction and the same one is used for each subsequent explanation on the same plot, which raises problems primarily when considering explainers for different models/classes.

Below is an example of what the explanation for the multiclass model looks like with unbalanced labels. On the left the explanations before the change, on the right - after the change. 

![fix_illustration](https://user-images.githubusercontent.com/56126737/214910467-1641d50a-6186-41f3-a894-d24435e9d02c.png)

