### PR TITLE
Issue #571: Compatibility with >= Numpy 2.0.0 (update of ptp method)

### DIFF
--- a/python/dalex/NEWS.md
+++ b/python/dalex/NEWS.md
@@ -2,6 +2,7 @@
 
 ### development
 
+* replaced instances of x.ptp() (with np.ptp(x)) and np.Inf (with np.inf) to make dx compatible with Numpy>=2.0.0
 * added a way to pass `sample_weight` to loss functions in `model_parts()` (variable importance) using `weights` from `dx.Explainer` ([#563](https://github.com/ModelOriented/DALEX/issues/563))
 * fixed the visualization of `shap_wrapper` for `shap==0.45.0`
 

--- a/python/dalex/dalex/aspect/_model_aspect_importance/object.py
+++ b/python/dalex/dalex/aspect/_model_aspect_importance/object.py
@@ -246,7 +246,7 @@ class ModelAspectImportance(VariableImportance):
         dl = _result_df.loc[
             _result_df.aspect_name != "_baseline_", "dropout_loss"
         ].to_numpy()
-        min_max_margin = dl.ptp() * 0.15
+        min_max_margin = np.ptp(dl) * 0.15
         min_max = [dl.min() - min_max_margin, dl.max() + min_max_margin]
 
         # take out full model

--- a/python/dalex/dalex/aspect/_model_triplot/object.py
+++ b/python/dalex/dalex/aspect/_model_triplot/object.py
@@ -231,7 +231,7 @@ class ModelTriplot(Explanation):
         fig.data[0]["y"] = y_vals
 
         ## triplot
-        min_x_imp, max_x_imp = np.Inf, -np.Inf
+        min_x_imp, max_x_imp = np.inf, -np.inf
         for data in hierarchical_importance_dendrogram_plot["data"][::-1]:
             data["xaxis"] = "x2"
             data["hoverinfo"] = "text"
@@ -241,7 +241,7 @@ class ModelTriplot(Explanation):
             max_x_imp = np.max([max_x_imp, np.max(data["x"])])
         min_max_margin_imp = (max_x_imp - min_x_imp) * 0.15
 
-        min_x_clust, max_x_clust = np.Inf, -np.Inf
+        min_x_clust, max_x_clust = np.inf, -np.inf
         for data in hierarchical_clustering_dendrogram_plot["data"]:
             data["xaxis"] = "x3"
             data["hoverinfo"] = "text"

--- a/python/dalex/dalex/aspect/_model_triplot/plot.py
+++ b/python/dalex/dalex/aspect/_model_triplot/plot.py
@@ -148,7 +148,7 @@ def plot_single_aspects_importance(
         }
     )
 
-    temp_min_max = [np.Inf, -np.Inf]
+    temp_min_max = [np.inf, -np.inf]
     min_max_margin = np.ptp(_result.dropout_loss.values) * 0.15
     temp_min_max[0] = np.min(
         [temp_min_max[0], baseline - min_max_margin]

--- a/python/dalex/dalex/aspect/_model_triplot/plot.py
+++ b/python/dalex/dalex/aspect/_model_triplot/plot.py
@@ -149,7 +149,7 @@ def plot_single_aspects_importance(
     )
 
     temp_min_max = [np.Inf, -np.Inf]
-    min_max_margin = _result.dropout_loss.values.ptp() * 0.15
+    min_max_margin = np.ptp(_result.dropout_loss.values) * 0.15
     temp_min_max[0] = np.min(
         [temp_min_max[0], baseline - min_max_margin]
     )

--- a/python/dalex/dalex/aspect/_predict_aspect_importance/object.py
+++ b/python/dalex/dalex/aspect/_predict_aspect_importance/object.py
@@ -404,7 +404,7 @@ class PredictAspectImportance(Explanation):
 
             if min_max is None:
                 cum = _result.importance.values + baseline
-                min_max_margin =  cum.ptp() * 0.15 
+                min_max_margin =  np.ptp(cum) * 0.15 
                 temp_min_max[0] = np.min(
                     [
                         temp_min_max[0],

--- a/python/dalex/dalex/aspect/_predict_aspect_importance/object.py
+++ b/python/dalex/dalex/aspect/_predict_aspect_importance/object.py
@@ -306,7 +306,7 @@ class PredictAspectImportance(Explanation):
             vcolors = _theme.get_aspect_importance_colors()
 
         if min_max is None:
-            temp_min_max = [np.Inf, -np.Inf]
+            temp_min_max = [np.inf, -np.inf]
         else:
             temp_min_max = min_max
 

--- a/python/dalex/dalex/aspect/_predict_triplot/object.py
+++ b/python/dalex/dalex/aspect/_predict_triplot/object.py
@@ -284,7 +284,7 @@ class PredictTriplot(Explanation):
             line={"color": "#371ea3", "width": 1.5, "dash": "dot"},
         )
 
-        min_x_imp, max_x_imp = np.Inf, -np.Inf
+        min_x_imp, max_x_imp = np.inf, -np.inf
         for data in hierarchical_importance_dendrogram_plot["data"][::-1]:
             data["xaxis"] = "x2"
             data["hoverinfo"] = "text"
@@ -294,7 +294,7 @@ class PredictTriplot(Explanation):
             max_x_imp = np.max([max_x_imp, np.max(data["x"])])
         min_max_margin_imp = (max_x_imp - min_x_imp) * 0.15
 
-        min_x_clust, max_x_clust = np.Inf, -np.Inf
+        min_x_clust, max_x_clust = np.inf, -np.inf
         for data in hierarchical_clustering_dendrogram_plot["data"]:
             data["xaxis"] = "x3"
             data["hoverinfo"] = "text"

--- a/python/dalex/dalex/aspect/_predict_triplot/plot.py
+++ b/python/dalex/dalex/aspect/_predict_triplot/plot.py
@@ -240,7 +240,7 @@ def plot_single_aspects_importance(
     )
 
     temp_min_max = [np.Inf, -np.Inf]
-    min_max_margin = _result.importance.values.ptp() * 0.15
+    min_max_margin = np.ptp(_result.importance.values) * 0.15
     temp_min_max[0] = np.min(
         [temp_min_max[0], _result.importance.values.min() - min_max_margin]
     )

--- a/python/dalex/dalex/aspect/_predict_triplot/plot.py
+++ b/python/dalex/dalex/aspect/_predict_triplot/plot.py
@@ -239,7 +239,7 @@ def plot_single_aspects_importance(
         }
     )
 
-    temp_min_max = [np.Inf, -np.Inf]
+    temp_min_max = [np.inf, -np.inf]
     min_max_margin = np.ptp(_result.importance.values) * 0.15
     temp_min_max[0] = np.min(
         [temp_min_max[0], _result.importance.values.min() - min_max_margin]

--- a/python/dalex/dalex/model_explanations/_aggregated_profiles/object.py
+++ b/python/dalex/dalex/model_explanations/_aggregated_profiles/object.py
@@ -242,7 +242,7 @@ class AggregatedProfiles(Explanation):
 
         #  calculate y axis range to allow for fixedrange True
         dl = _result_df['_yhat_'].to_numpy()
-        min_max_margin = dl.ptp() * 0.10
+        min_max_margin = np.ptp(dl) * 0.10
         min_max = [dl.min() - min_max_margin, dl.max() + min_max_margin]
 
         is_x_numeric = False if geom == 'bars' else pd.api.types.is_numeric_dtype(_result_df['_x_'])

--- a/python/dalex/dalex/model_explanations/_variable_importance/object.py
+++ b/python/dalex/dalex/model_explanations/_variable_importance/object.py
@@ -198,7 +198,7 @@ class VariableImportance(Explanation):
             _global_checks.global_raise_objects_class(objects, self.__class__)
 
         dl = _result_df.loc[_result_df.variable != '_baseline_', 'dropout_loss'].to_numpy()
-        min_max_margin = dl.ptp() * 0.15
+        min_max_margin = np.ptp(dl) * 0.15
         min_max = [dl.min() - min_max_margin, dl.max() + min_max_margin]
 
         # take out full model

--- a/python/dalex/dalex/predict_explanations/_break_down/object.py
+++ b/python/dalex/dalex/predict_explanations/_break_down/object.py
@@ -199,7 +199,7 @@ class BreakDown(Explanation):
             vcolors = _theme.get_break_down_colors()
 
         if min_max is None:
-            temp_min_max = [np.Inf, -np.Inf]
+            temp_min_max = [np.inf, -np.inf]
         else:
             temp_min_max = min_max
 

--- a/python/dalex/dalex/predict_explanations/_break_down/object.py
+++ b/python/dalex/dalex/predict_explanations/_break_down/object.py
@@ -256,7 +256,7 @@ class BreakDown(Explanation):
 
             if min_max is None:
                 cum = df.cumulative.values
-                min_max_margin = cum.ptp() * 0.15
+                min_max_margin = np.ptp(cum) * 0.15
                 temp_min_max[0] = np.min([temp_min_max[0], cum.min() - min_max_margin])
                 temp_min_max[1] = np.max([temp_min_max[1], cum.max() + min_max_margin])
 

--- a/python/dalex/dalex/predict_explanations/_ceteris_paribus/object.py
+++ b/python/dalex/dalex/predict_explanations/_ceteris_paribus/object.py
@@ -262,7 +262,7 @@ class CeterisParibus(Explanation):
 
         #  calculate y axis range to allow for fixedrange True
         dl = _result_df['_yhat_'].to_numpy()
-        min_max_margin = dl.ptp() * 0.10
+        min_max_margin = np.ptp(dl) * 0.10
         min_max = [dl.min() - min_max_margin, dl.max() + min_max_margin]
 
         # create _x_

--- a/python/dalex/dalex/predict_explanations/_shap/object.py
+++ b/python/dalex/dalex/predict_explanations/_shap/object.py
@@ -205,7 +205,7 @@ class Shap(Explanation):
             vcolors = _theme.get_break_down_colors()
 
         if min_max is None:
-            temp_min_max = [np.Inf, -np.Inf]
+            temp_min_max = [np.inf, -np.inf]
         else:
             temp_min_max = min_max
 

--- a/python/dalex/dalex/predict_explanations/_shap/object.py
+++ b/python/dalex/dalex/predict_explanations/_shap/object.py
@@ -263,7 +263,7 @@ class Shap(Explanation):
 
             if min_max is None:
                 cum = df.contribution.values + prediction_baseline
-                min_max_margin = cum.ptp() * 0.15
+                min_max_margin = np.ptp(cum) * 0.15
                 temp_min_max[0] = np.min([temp_min_max[0], cum.min() - min_max_margin])
                 temp_min_max[1] = np.max([temp_min_max[1], cum.max() + min_max_margin])
 


### PR DESCRIPTION
#571 

**In this PR:**

- Replaced use of x.ptp() with np.ptp(x) as per depreciation of x.ptp() as part of migration to Numpy 2.0.0.
- Although not raised in original issue, when running tests noticed that they have also depreciated the use of np.Inf to ensure there is only one way to call the attribute. Therefore have replaced np.Inf with np.inf where it appears in package.

**Notes:**

- Existing unit tests cover changes