### PR TITLE
Fix aes_string() deprecation warning in diagnostics plots (#582)

### DIFF
--- a/R/plot_model_diagnostics.R
+++ b/R/plot_model_diagnostics.R
@@ -37,7 +37,7 @@ plot.model_diagnostics <- function(x, ..., variable = "y_hat", yvariable = "resi
   class(all_models) <- "data.frame"
   nlabels <- length(unique(all_models$label))
 
-   pl <- ggplot(all_models, aes_string(x = variable, y = yvariable, color = "label", group = "label")) +
+   pl <- ggplot(all_models, aes(x = .data[[variable]], y = .data[[yvariable]], color = .data[["label"]], group = .data[["label"]])) +
     geom_point(size = 0.1) +
     theme_default_dalex() +
     scale_color_manual(name = "Model", values = colors_discrete_drwhy(nlabels))

--- a/R/plot_predict_diagnostics.R
+++ b/R/plot_predict_diagnostics.R
@@ -39,7 +39,7 @@ plot.predict_diagnostics <- function(x, ...) {
     statistic <- x$test$statistic
     cut_points <- x$cut_points
 
-    pl <- ggplot(df, aes_string("Var1", "Freq", fill = "direction")) +
+    pl <- ggplot(df, aes(x = .data[["Var1"]], y = .data[["Freq"]], fill = .data[["direction"]])) +
       geom_col() +
       scale_y_continuous("") +
       scale_x_discrete("residuals", labels = as.character(cut_points)) +

--- a/tests/testthat/test_model_diagnostics.R
+++ b/tests/testthat/test_model_diagnostics.R
@@ -49,6 +49,25 @@ test_that("Print",{
   expect_error(print(diag_ranger_3), NA)
 })
 
+test_that("Plot does not use deprecated aes_string() (#582)", {
+  # ggplot2 >= 3.0.0 hard-deprecates aes_string(); plot.model_diagnostics()
+  # used to call it directly, which raised a `lifecycle::deprecate_warn()`
+  # every time a diagnostics plot was drawn (see reprex in issue #582).
+  #
+  # We check this structurally (source no longer references aes_string())
+  # rather than by capturing the warning at call time, because lifecycle
+  # warnings are only emitted once per R session: whichever test runs
+  # plot.model_diagnostics() first "uses up" the warning for the rest of
+  # the session/suite, which would make a warning-capturing test silently
+  # pass regardless of whether the bug is actually fixed.
+  plot_fun_src <- deparse(body(getS3method("plot", "model_diagnostics")))
+  expect_false(any(grepl("aes_string", plot_fun_src, fixed = TRUE)))
+
+  # the plot itself must still work and produce a ggplot object
+  expect_is(plot(diag_ranger_1), "gg")
+  expect_is(plot(diag_ranger_1, diag_lm, variable = "construction.year"), "gg")
+})
+
 explainer_array <- explainer_ranger
 explainer_array$y_hat <- as.array(explainer_array$y_hat)
 

--- a/tests/testthat/test_predict_diagnostics.R
+++ b/tests/testthat/test_predict_diagnostics.R
@@ -21,6 +21,19 @@ test_that("Output format - plot",{
   expect_is(plot(lm_rd), "gg")
 })
 
+test_that("Plot does not use deprecated aes_string() (#582)", {
+  # Same root cause as plot.model_diagnostics(): the histogram branch of
+  # plot.predict_diagnostics() (used when variables = NULL) also called the
+  # deprecated aes_string(). See test_model_diagnostics.R for why this is
+  # checked structurally instead of via expect_no_warning() (lifecycle
+  # deprecation warnings only fire once per R session).
+  plot_fun_src <- deparse(body(getS3method("plot", "predict_diagnostics")))
+  expect_false(any(grepl("aes_string", plot_fun_src, fixed = TRUE)))
+
+  ranger_rd_hist <- predict_diagnostics(explainer_classif_ranger, new_observation = titanic_imputed[1, -8], variables = NULL)
+  expect_is(plot(ranger_rd_hist), "gg")
+})
+
 
 #:# alias
 


### PR DESCRIPTION
## Summary

`ggplot2` >= 3.0.0 hard-deprecates `aes_string()`. Both `plot.model_diagnostics()` and `plot.predict_diagnostics()` called it directly, so every diagnostics plot emitted a `lifecycle` deprecation warning:

```
Warning message:
`aes_string()` was deprecated in ggplot2 3.0.0.
ℹ Please use tidy evaluation idioms with `aes()`.
```

Reproduced exactly using the reprex from #582:

```r
library(DALEX)
library(randomForest)
set.seed(72)

model_apart_rf <- randomForest(m2.price ~ ., data = apartments)
explain_apart_rf <- DALEX::explain(
  model = model_apart_rf, verbose = FALSE,
  data = apartments_test[, -1], y = apartments_test$m2.price,
  label = "Random Forest"
)

diag_rf <- model_diagnostics(explain_apart_rf)
plot(diag_rf)  # <- warning fired here, pre-fix
```

**Root cause / fix:** both functions built their `aes()` mapping with variable-name *strings* (column names passed in as function arguments, e.g. `variable = "y_hat"`), which is exactly what `aes_string()` was for before tidy evaluation existed. The fix swaps in `aes()` + `.data[[...]]`, which is the direct replacement `ggplot2`'s own deprecation message points to, and keeps the "map by column-name string" behavior these functions depend on (`variable`/`yvariable` are user-facing string parameters).

While tracing this, I found `plot.predict_diagnostics()`'s histogram branch (used when `variables = NULL`) has the exact same latent bug — not mentioned in the issue title, but same root cause and same file area, so fixed it too rather than leaving a near-identical bug in place.

```mermaid
flowchart LR
    A["model_diagnostics(explainer)"] --> B["plot.model_diagnostics()"]
    B --> C["ggplot(all_models, aes_string(...))\n⚠ deprecated in ggplot2 >= 3.0.0"]
    C -->|"this PR"| D["ggplot(all_models, aes(x = .data[[variable]], ...))"]

    E["predict_diagnostics(explainer, ..., variables = NULL)"] --> F["plot.predict_diagnostics()\n(histogram branch)"]
    F --> G["ggplot(df, aes_string(...))\n⚠ same deprecation"]
    G -->|"this PR"| H["ggplot(df, aes(x = .data[[\"Var1\"]], ...))"]
```

## Why it matters

`model_diagnostics()`/`plot()` and `predict_diagnostics()`/`plot()` are core, commonly-used entry points (residual diagnostics, instance-level diagnostics). The warning fires on every single call, which is noisy for users and — since `lifecycle` warnings can be promoted to errors by `options(lifecycle_verbosity = "error")` or under strict CRAN checks on newer `ggplot2` — a forward-compatibility risk, not just cosmetic noise.

## Test plan

- [x] Reproduced the exact warning from #582's reprex against current `master`.
- [x] Added a regression test to `tests/testthat/test_model_diagnostics.R` and `tests/testthat/test_predict_diagnostics.R` that asserts the plotting functions' source no longer references `aes_string()`.
  - Checked this structurally (source inspection) rather than via `expect_warning`/`expect_no_warning`, because `lifecycle` deprecation warnings are only emitted **once per R session** — whichever test calls `plot.model_diagnostics()` first "uses up" the warning, so a warning-capturing test would silently pass on later calls in the same test run regardless of whether the underlying bug is fixed. Confirmed this empirically before choosing the structural check.
- [x] Verified both new tests **fail** against the pre-fix source (`failed: 1`) and **pass** after the fix (`failed: 0`), by checking out the pre-fix version of the two `R/` files, rebuilding, and rerunning `testthat::test_file()` on just the two affected test files, then restoring the fix and rerunning.
- [x] Ran the full existing `test_model_diagnostics.R` and `test_predict_diagnostics.R` suites (not just the new tests) after the fix — all pass, and the pre-existing `"Plot"` tests no longer emit the `aes_string()` warning either.
- [x] Verified the fixed plots produce identical data mappings (`gg` object, correct columns bound to x/y/color/fill) — this is a call-site swap, not a behavior change.

Ran only the two affected test files locally (per this session's scoped-testing convention); full `R CMD check` / CI will run the complete suite.

Closes #582
